### PR TITLE
Fix 'run --no-send'

### DIFF
--- a/rss2email.py
+++ b/rss2email.py
@@ -941,7 +941,7 @@ if __name__ == '__main__':
         
         if action == "run": 
             if args and args[0] == "--no-send":
-                def send(sender, recipient, subject, body, contenttype, extraheaders=None, mailserver=None):
+                def send(sender, recipient, subject, body, contenttype, datetime, extraheaders=None, mailserver=None, folder=None):
                     if VERBOSE: print 'Not sending:', unu(subject)
 
             if args and args[-1].isdigit(): run(int(args[-1]))


### PR DESCRIPTION
The --no-send option is implemented by monkey-patching the send function to one that doesn't actually send.

The signature of the real function has changed, but the null function has not, causing `run --no-send` to fail.

This patch updates the null signature to match the real one.
