### PR TITLE
Alpha implementation of OPML import with folders specified in OPML file

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -124,3 +124,6 @@ DEFAULT_IMAP_FOLDER = "INBOX"
 
 # Whether to summarize the body or not. Set it to the number of sentences you require.
 SUMMARIZE = 0
+
+# When set to "1", during OPML import, the title tag of parent "outline" element is used as folder path
+USE_OPML_TITLE_AS_FOLDER = O

--- a/rss2email.py
+++ b/rss2email.py
@@ -863,23 +863,23 @@ def opmlexport():
     
     if feeds:
         print '<?xml version="1.0" encoding="UTF-8"?>\n<opml version="1.0">\n<head>\n<title>rss2email OPML export</title>\n</head>\n<body>'
-		exportableFeeds = {:}
-		if USE_OPML_TITLE_AS_FOLDER:
-			for f in feeds[1:]:
-				if not hasattr(exportableFeeds, f.folder):
-					exportableFeeds[f.folder] = {}
-				exportableFeeds[f.folder].append(f)
+        exportableFeeds = {}
+        if USE_OPML_TITLE_AS_FOLDER:
+            for f in feeds[1:]:
+                if not hasattr(exportableFeeds, f.folder):
+                    exportableFeeds[f.folder] = {}
+                exportableFeeds[f.folder].append(f)
 
-			for folder in exportableFeeds:
-				print '\n\t<outline text="%s" title="%s">' % (folder, folder)
-				for f in exportableFeeds[folder]:
-					url = xml.sax.saxutils.escape(f.url)
-					print '\n\t\t<outline type="rss" text="%s" xmlUrl="%s"/>' % (url, url)
-				print '\n\t</outline>'
-		else:
-	        for f in feeds[1:]:
-				url = xml.sax.saxutils.escape(f.url)
-				print '<outline type="rss" text="%s" xmlUrl="%s"/>' % (url, url)
+            for folder in exportableFeeds:
+                print '\n\t<outline text="%s" title="%s">' % (folder, folder)
+                for f in exportableFeeds[folder]:
+                    url = xml.sax.saxutils.escape(f.url)
+                    print '\n\t\t<outline type="rss" text="%s" xmlUrl="%s"/>' % (url, url)
+                print '\n\t</outline>'
+        else:
+            for f in feeds[1:]:
+                url = xml.sax.saxutils.escape(f.url)
+                print '<outline type="rss" text="%s" xmlUrl="%s"/>' % (url, url)
         print '\n</body>\n</opml>'
 
 def opmlimport(importfile):

--- a/rss2email.py
+++ b/rss2email.py
@@ -863,10 +863,24 @@ def opmlexport():
     
     if feeds:
         print '<?xml version="1.0" encoding="UTF-8"?>\n<opml version="1.0">\n<head>\n<title>rss2email OPML export</title>\n</head>\n<body>'
-        for f in feeds[1:]:
-            url = xml.sax.saxutils.escape(f.url)
-            print '<outline type="rss" text="%s" xmlUrl="%s"/>' % (url, url)
-        print '</body>\n</opml>'
+		exportableFeeds = {:}
+		if USE_OPML_TITLE_AS_FOLDER:
+			for f in feeds[1:]:
+				if not hasattr(exportableFeeds, f.folder):
+					exportableFeeds[f.folder] = {}
+				exportableFeeds[f.folder].append(f)
+
+			for folder in exportableFeeds:
+				print '\n\t<outline text="%s" title="%s">' % (folder, folder)
+				for f in exportableFeeds[folder]:
+					url = xml.sax.saxutils.escape(f.url)
+					print '\n\t\t<outline type="rss" text="%s" xmlUrl="%s"/>' % (url, url)
+				print '\n\t</outline>'
+		else:
+	        for f in feeds[1:]:
+				url = xml.sax.saxutils.escape(f.url)
+				print '<outline type="rss" text="%s" xmlUrl="%s"/>' % (url, url)
+        print '\n</body>\n</opml>'
 
 def opmlimport(importfile):
     importfileObject = None

--- a/rss2email.py
+++ b/rss2email.py
@@ -892,9 +892,14 @@ def opmlimport(importfile):
     
     for f in newfeeds:
         if f.hasAttribute('xmlUrl'):
+            category = f.parentNode
+            folder = None
+            if USE_OPML_TITLE_AS_FOLDER:
+                if category.hasAttribute("title")!=None:
+                    folder = category.getAttribute("title")
             feedurl = f.getAttribute('xmlUrl')
             print 'Adding %s' % xml.sax.saxutils.unescape(feedurl)
-            feeds.append(Feed(feedurl, None))
+            feeds.append(Feed(feedurl, None, folder))
             
     unlock(feeds, feedfileObject)
 


### PR DESCRIPTION
To clarify, the goal is to have in my OPML file containing various RSS sources, that should go into various IMAP folders. To ensure it is easy, OPML file is described the following way

```
<outline text="work" title="RSS/work">
     <outline text="The Tao of Mac" type="rss" title="The Tao of Mac" xmlUrl="http://taoofmac.com/rss" htmlUrl="http://taoofmac.com" />
     .
     .
     .
 </outline>
```

This will import all RSS feeds into the RSS/work folder, whatever the default RSS folder is.
However, to ensure this behaviour stays optional, a config.py option has been added : `USE_OPML_TITLE_AS_FOLDER`, which must be set to true to enable this feature. I'm not sure it's the best way, but it ensure all this behaviour is an opt-in option.
